### PR TITLE
fix(io): 增加苹果系统下非标准波特率支持

### DIFF
--- a/src/ws63flash.c
+++ b/src/ws63flash.c
@@ -101,7 +101,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 			speed_found = 1;
 			break;
 		}
-
+#ifndef __APPLE__
 		if (!speed_found) {
 			fprintf(stderr,
 				"Target baud %d not found,"
@@ -112,7 +112,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 			putchar('\n');
 			exit(EXIT_FAILURE);
 		}
-
+#endif
 		args->baud = baud;
 		break;
 	case 'v':


### PR DESCRIPTION
- 在 io.h 中添加了苹果系统特有的头文件包含
- 实现了苹果系统下通过 IOSSIOSPEED ioctl 设置自定义波特率的方法
- 更新了 uart_open 函数以支持非标准波特率
- 修改了 ws63flash.c 中的错误处理，以适应苹果系统的特性
- 目前测试Macbook 2021 M1 pro 支持最大支持1152000波特率 